### PR TITLE
ci: enable aarch64 ubuntu runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,13 +34,13 @@ jobs:
             binary-postfix: ""
             use-cross: false
             binary-name: cargo-seek
-#          - os: ubuntu-22.04
-#            os-name: linux
-#            target: aarch64-unknown-linux-gnu
-#            architecture: arm64
-#            binary-postfix: ""
-#            use-cross: true
-#            binary-name: cargo-seek
+          - os: ubuntu-22.04-arm
+            os-name: linux
+            target: aarch64-unknown-linux-gnu
+            architecture: arm64
+            binary-postfix: ""
+            use-cross: false
+            binary-name: cargo-seek
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
fixes #5
